### PR TITLE
Fix CVSS extraction to return full scores

### DIFF
--- a/processors/data_processor.py
+++ b/processors/data_processor.py
@@ -20,7 +20,7 @@ def extract_cve(text):
 def extract_cvss(text):
     """CVSSスコアを抽出する"""
     cvss_pattern = re.compile(r"CVSS[:\s]?([0-9]\.[0-9])", re.IGNORECASE)
-    return ", ".join(set(match[0] for match in cvss_pattern.findall(text)))
+    return ", ".join(set(match.strip() for match in cvss_pattern.findall(text)))
 
 
 def fetch_cvss_from_nvd(cve):


### PR DESCRIPTION
## Summary
- capture and join full CVSS scores instead of first character

## Testing
- `python -m py_compile processors/data_processor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adc8b55d608322ae25059a84e1a8d4