### PR TITLE
chore: schedule RSS updates on weekdays

### DIFF
--- a/.github/workflows/update-rss.yml
+++ b/.github/workflows/update-rss.yml
@@ -1,9 +1,9 @@
 name: Update RSS Feed
 
 on:
-  #   schedule:
-  # 平日 09:00 ～ 17:00 は 20分に1回
-  # - cron: "*/20 9-17 * * 1-5"
+  schedule:
+    # 平日 09:00 ～ 18:00 は 20分に1回
+    - cron: "*/20 9-18 * * 1-5"
 
   workflow_dispatch: # 手動実行も可能
 


### PR DESCRIPTION
## Summary
- Run RSS update workflow every 20 minutes on weekdays from 09:00 to 18:00

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfc984df883229d35a4b6fed1ce18