### PR TITLE
Add network timeouts to data fetchers

### DIFF
--- a/data_fetchers/fetch_beautifulsoup.py
+++ b/data_fetchers/fetch_beautifulsoup.py
@@ -9,7 +9,9 @@ from utils.date_utils import normalize_date
 
 def fetch_data_with_beautifulsoup(config):
     try:
-        response = requests.get(config["url"])
+        # ネットワーク障害などで無限に待機し続けることを防ぐため、
+        # requests.get にタイムアウトを設定する。
+        response = requests.get(config["url"], timeout=30)
         response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
 


### PR DESCRIPTION
## Summary
- prevent indefinite hangs by adding timeouts to BeautifulSoup and RSS fetchers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from config.site_config import SITE_CONFIG
from data_fetchers.fetch_beautifulsoup import fetch_data_with_beautifulsoup
print('Fetching Zoom Security Bulletin...')
data = fetch_data_with_beautifulsoup(SITE_CONFIG['Zoom Security Bulletin'])
print(f'Fetched {len(data)} entries')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ae0228c98c83228e9eb22816fa2d34