### PR TITLE
Fix commit step in RSS workflow

### DIFF
--- a/.github/workflows/update-rss.yml
+++ b/.github/workflows/update-rss.yml
@@ -40,6 +40,6 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
-          git add rss.xml
-          git commit -m "Update RSS feed" || exit 0
+          git add .
+          git commit -m "Update RSS feed"
           git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main


### PR DESCRIPTION
## Summary
- stage all generated data files during RSS workflow
- fail commit step when no RSS updates are produced

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae068ded8c832290ddbe924dd876cd