### PR TITLE
Fix Barracuda advisory selectors and EmEditor feed UA

### DIFF
--- a/config/site_config.py
+++ b/config/site_config.py
@@ -301,10 +301,10 @@ SITE_CONFIG = {
         "method": "beautifulsoup",
         "url": "https://www.barracuda.com/company/legal/security-advisory",
         "selectors": {
-            "rows": "div.cmp-text.cmp-text--v1",
-            "title": "span.cmp-text__rte__text-subtitle1 a",
-            "link": "span.cmp-text__rte__text-subtitle1 a",
-            "date": "span.cmp-text__rte__text-body1",
+            "rows": "tr.cmp-table-row:not(.cmp-table__container__table__row--header)",
+            "title": "td:nth-of-type(1) a",
+            "link": "td:nth-of-type(1) a",
+            "date": "td:nth-of-type(2) div",
         },
         "date_formats": ["%B %d, %Y"],
         "filter_description_keywords": [],
@@ -658,7 +658,7 @@ EXCEL_FILE = r"FilterVulnerability.xlsx"
 LOG_FILE = r"vulnerability_logger.log"
 
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
+    "User-Agent": "Mozilla/5.0"
 }
 
 # タイムゾーン情報


### PR DESCRIPTION
## Summary
- Update BarracudaAdvisories selectors to match current table layout
- Set generic `Mozilla/5.0` user agent in shared headers for EmEditor RSS access

## Testing
- `python - <<'PY'
import requests
from config.site_config import HEADERS
print('headers', HEADERS)
print('status', requests.get('https://jp.emeditor.com/blog/feed/', headers=HEADERS).status_code)
PY`
- `python - <<'PY'
import requests, bs4
from config.site_config import SITE_CONFIG
cfg = SITE_CONFIG['BarracudaAdvisories']
html = requests.get(cfg['url']).text
soup = bs4.BeautifulSoup(html, 'html.parser')
rows = soup.select(cfg['selectors']['rows'])
print('rows', len(rows))
print('first title', rows[0].select_one(cfg['selectors']['title']).text.strip())
PY`
- ⚠️ `python main.py` (fails on Selenium sites due to missing Chrome)`

------
https://chatgpt.com/codex/tasks/task_e_68b48f00da5883228a91ee0a37883d99